### PR TITLE
Add CRAN install and syntax highlighting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ package is **baw**-ler.
 
 ## To install:
 
-```
+```r
 install.packages("devtools")
 library(devtools)
 install_github("rtelmore/ballr")

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ package is **baw**-ler.
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/ballr)](http://www.r-pkg.org/pkg/ballr)
 [![DOI](https://zenodo.org/badge/45419870.svg)](https://zenodo.org/badge/latestdoi/45419870)
 
-## To install:
+## To install
 
+From CRAN:
+```r
+install.packages("ballr")
+```
+
+The development version from GitHub:
 ```r
 install.packages("devtools")
 library(devtools)


### PR DESCRIPTION
Hi Ryan,

Great package (obvi). Just added syntax highlighting to the README (pop a little `r` next to the opening backticks), and then realized the CRAN install option wasn't there — so, I added that too!

Keep on ballin' 🏀